### PR TITLE
HIP build clobbers user specified CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,8 @@ if(HIP_PLATFORM STREQUAL "hcc")
     set(CMAKE_C_COMPILER   "${HCC_HOME}/bin/hcc")
 
     # Set HIP_HCC so we know this is HIP compile, some files are shared with HCC (staging_buffer).
-    set(CMAKE_CXX_FLAGS " -hc -I${HCC_HOME}/include -I${HSA_PATH}/include -stdlib=libc++ -DHIP_HCC")
-    set(CMAKE_C_FLAGS   " -hc -I${HCC_HOME}/include -I${HSA_PATH}/include -stdlib=libc++ -DHIP_HCC")
+    set(CMAKE_CXX_FLAGS " -hc -I${HCC_HOME}/include -I${HSA_PATH}/include -stdlib=libc++ -DHIP_HCC ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS   " -hc -I${HCC_HOME}/include -I${HSA_PATH}/include -stdlib=libc++ -DHIP_HCC ${CMAKE_C_FLAGS}")
 
     set(SOURCE_FILES src/device_util.cpp
                      src/hip_hcc.cpp 


### PR DESCRIPTION
Users should be able to pass in their own compilation flags into
hip cmake project through -DCMAKE_CXX_FLAGS and -DCMAKE_C_FLAGS.  The
root cmakefile unconditionally clobbers user values.  Instead,
hip build should append implementation flags.