### PR TITLE
correct spelling in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Differences or limitations of HIP APIs as compared to CUDA APIs should be clearl
 
 - All HIP environment variables should begin with the keyword HIP_
     Environment variables should be long enough to describe their purpose but short enough so they can be remembered - perhaps 10-20 characters, with 3-4 parts separated by underscores.
-    To see the list of current environment variables, along with their values, set HIP_PRINT_ENV and run any hip applications on ROCM platform .
+    To see the list of current environment variables, along with their values, set HIP_PRINT_ENV and run any hip applications on ROCm platform .
     HIPCC or other tools may support additional environment variables which should follow the above convention.  
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ HIP code can be developed either on AMD ROCm platform using hcc compiler, or a C
 
 ## AMD-hcc
 
-* Install the [rocm](http://gpuopen.com/getting-started-with-boltzmann-components-platforms-installation/) packages.  Rocm will install all of the necessary components, including the kernel driver, runtime software, HCC compiler, and HIP.
+* Install the [rocm](http://gpuopen.com/getting-started-with-boltzmann-components-platforms-installation/) packages.  ROCm will install all of the necessary components, including the kernel driver, runtime software, HCC compiler, and HIP.
 
 * Default paths and environment variables:
 
@@ -96,7 +96,7 @@ The native GCN target is included with upstream LLVM, and has also been integrat
 Binary packages for the direct-to-isa package are included with the [rocm](http://gpuopen.com/getting-started-with-boltzmann-components-platforms-installation/) package. 
 Alternatively, this sections describes how to build it from source: 
 
-1. Install the rocm packages as described above.
+1. Install the ROCm packages as described above.
 2. Follow the instructions [here](https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA/wiki)
    * In the make step for HCC, we recommend setting -DCMAKE_INSTALL_PREFIX.  
    * Set HCC_HOME environment variable before compiling HIP program to point to the native compiler:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ HIP code can be developed either on AMD ROCm platform using hcc compiler, or a C
    * By default HIP looks for hcc in /opt/rocm/hcc (can be overridden by setting HCC_HOME environment variable)
    * By default HIP looks for HSA in /opt/rocm/hsa (can be overridden by setting HSA_PATH environment variable) 
    * By default HIP is installed into /opt/rocm/hip (can be overridden by setting HIP_PATH environment variable).
-   * Optionally, consider adding /opt/rocm/bin to your path to make it easier to use the tools.
+   * Optionally, consider adding /opt/rocm/bin to your PATH to make it easier to use the tools.
 
 
 ## NVIDIA-nvcc

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The HIP Runtime API code and compute kernel definition can exist in the same sou
 ## HIP Portability and Compiler Technology
 HIP C++ code can be compiled with either :
 - On the Nvidia CUDA platform, HIP provides header file which translate from the HIP runtime APIs to CUDA runtime APIs.  The header file contains mostly inlined 
-  functions and thus has very low overhead - developers coding in HIP should expect the same perforamnce as coding in native CUDA.  The code is then 
+  functions and thus has very low overhead - developers coding in HIP should expect the same performance as coding in native CUDA.  The code is then 
   compiled with nvcc, the standard C++ compiler provided with the CUDA SDK.  Developers can use any tools supported by the CUDA SDK including the CUDA
   profiler and debugger.
 - On the AMD ROCm platform, HIP provides a header and runtime library built on top of hcc compiler.  The HIP runtime implements HIP streams, events, and memory APIs, 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 We have attempted to document known bugs and limitations - in particular the [HIP Kernel Language](docs/markdown/hip_kernel_language.md) document uses the phrase "Under Development", and the [HIP Runtime API bug list](http://gpuopen-professionalcompute-tools.github.io/HIP/bug.html) lists known bugs. 
 
 Upcoming:
-- Stability: Enforce perioidic host synchronization to reclaim resources if the application has launched a large
+- Stability: Enforce periodic host synchronization to reclaim resources if the application has launched a large
   number of commands (>1K) without synchronizing.  
 - Register keyword now silently ignored on HCC (previously would emit warning).
 - Doc updates: Add some more frequently asked questions to FAQ, fix TOC in some files, review.

--- a/docs/markdown/hip_faq.md
+++ b/docs/markdown/hip_faq.md
@@ -50,7 +50,7 @@ At a high-level, the following features are not supported:
 - Textures 
 - Dynamic parallelism (CUDA 5.0)
 - Managed memory (CUDA 6.5)
-- Graphics interoperation with OpenGL or Direct3D
+- Graphics interoperability with OpenGL or Direct3D
 - CUDA Driver API (Under Development)
 - CUDA IPC Functions (Under Development)
 
@@ -76,13 +76,13 @@ See the [API Support Table](CUDA_Runtime_API_functions_supported_by_HIP.md) for 
 
 
 ### Is HIP a drop-in replacement for CUDA?
-No. HIP provides porting tools which do most of the work do convert CUDA code into portable C++ code that uses the HIP APIs.
+No. HIP provides porting tools which do most of the work to convert CUDA code into portable C++ code that uses the HIP APIs.
 Most developers will port their code from CUDA to HIP and then maintain the HIP version. 
 HIP code provides the same performance as native CUDA code, plus the benefits of running on AMD platforms.
 
 ### What specific version of CUDA does HIP support?
-HIP APIs and features do not map to a specific CUDA version.  HIP provides a strong subset of functionality provided in CUDA, and the hipify tools can 
-scan code to identify any unsupported CUDA functions - this is very useful for identifying the specific features required by a given application.
+HIP APIs and features do not map to a specific CUDA version. HIP provides a strong subset of functionality provided in CUDA, and the hipify tools can 
+scan code to identify any unsupported CUDA functions - this is useful for identifying the specific features required by a given application.
 
 However, we can provide a rough summary of the features included in each CUDA SDK and the support level in HIP:
 
@@ -106,8 +106,8 @@ However, we can provide a rough summary of the features included in each CUDA SD
     - TBD.
 
 ### What libraries does HIP support?
-HIP includes growing support for the 4 key math libraries using hcBlas, hcFft, hcrng, and hcsparse).
-These offer pointer-based memory interfaces (as opposed to opaque buffers) and can be easily interfaces with other HCC code.  Developers should use conditional compliation if portability to nvcc systems is desired - using calls to cu* routines on one path and hc* routines on the other.  
+HIP includes growing support for the 4 key math libraries using hcBlas, hcFft, hcrng and hcsparse.
+These offer pointer-based memory interfaces (as opposed to opaque buffers) and can be easily interfaced with other HCC applications.  Developers should use conditional compilation if portability to nvcc systems is desired - using calls to cu* routines on one path and hc* routines on the other.  
 
 - [hcblas](https://bitbucket.org/multicoreware/hcblas)
 - [hcfft](https://bitbucket.org/multicoreware/hcfft)
@@ -131,47 +131,47 @@ HIP offers several benefits over OpenCL:
 ### How does porting CUDA to HIP compare to porting CUDA to OpenCL?
 Both HIP and CUDA are dialects of C++, and thus porting between them is relatively straightforward.
 Both dialects support templates, classes, lambdas, and other C++ constructs.
-As one example, the hipify tool was originally a perl script that used simple text conversions from CUDA to HIP.
-HIP and CUDA provide similar math library calls as well.  In summary, the HIP philospohy was to make the HIP language close enough to CUDA that the porting effort is relatively simple.
+As one example, the hipify tool was originally a Perl script that used simple text conversions from CUDA to HIP.
+HIP and CUDA provide similar math library calls as well.  In summary, the HIP philosophy was to make the HIP language close enough to CUDA that the porting effort is relatively simple.
 This reduces the potential for error, and also makes it easy to automate the translation.  HIP's goal is to quickly get the ported program running on both platforms with little manual intervention,
 so that the programmer can focus on performance optimizations.
 
 There have been several tools that have attempted to convert CUDA into OpenCL, such as CU2CL.  OpenCL is a C99-based kernel language (rather than C++) and also does not support single-source compilation.  
-As a result, the OpenCL syntax is quite different than CUDA, and the porting tools have to perform some heroic transformations to bridge this gap.
+As a result, the OpenCL syntax is different from CUDA, and the porting tools have to perform some heroic transformations to bridge this gap.
 The tools also struggle with more complex CUDA applications, in particular those that use templates, classes, or other C++ features inside the kernel.  
 
 
 ### What hardware does HIP support?
-- For AMD platforms, HIP runs on the same hardware that the HCC "hc" mode supports.  See the ROCM documentation for the list of supported platforms.
-- For Nvidia platforms, HIP requires Unified Memory and should run on a device which runs the CUDA SDK 6.0 or newer. We have tested the Nvidia Titan and K40.
+- For AMD platforms, HIP runs on the same hardware that the HCC "hc" mode supports.  See the ROCm documentation for the list of supported platforms.
+- For Nvidia platforms, HIP requires Unified Memory and should run on any device supporting CUDA SDK 6.0 or newer. We have tested the Nvidia Titan and Tesla K40.
 
 ### Does Hipify automatically convert all source code?
-Typically, Hipify can automatically convert almost all run-time code, and the coordinate indexing device code (i.e. threadIdx.x -> hipThreadIdx_x).  
+Typically, hipify can automatically convert almost all run-time code, and the coordinate indexing device code ( threadIdx.x -> hipThreadIdx_x ).  
 Most device code needs no additional conversion, since HIP and CUDA have similar names for math and built-in functions. 
 The hipify-clang tool will automatically modify the kernel signature as needed (automating a step that used to be done manually)
 Additional porting may be required to deal with architecture feature queries or with CUDA capabilities that HIP doesn't support. 
 In general, developers should always expect to perform some platform-specific tuning and optimization.
 
 ### What is NVCC?
-NVCC is Nvidia's compiler driver for compiling "CUDA C++" code into PTX or device code for Nvidia GPUs. It's a closed-source binary product that comes with CUDA SDKs.
+NVCC is Nvidia's compiler driver for compiling "CUDA C++" code into PTX or device code for Nvidia GPUs. It's a closed-source binary compiler that is provided by the CUDA SDK.
 
 ### What is HCC?
-HCC is AMD's compiler driver which compiles "heterogenous C++" code into HSAIL or GCN device code for AMD GPUs.  It's an open-source compiler based on recent versions of CLANG/LLVM.
+HCC is AMD's compiler driver which compiles "heterogeneous C++" code into HSAIL or GCN device code for AMD GPUs.  It's an open-source compiler based on recent versions of CLANG/LLVM.
 
 ### Why use HIP rather than supporting CUDA directly?
 While HIP is a strong subset of the CUDA, it is a subset.  The HIP layer allows that subset to be clearly defined and documented.
-Developers who code to the HIP API can be assured there code will remain portable across Nvidia and AMD platforms.  
+Developers who code to the HIP API can be assured their code will remain portable across Nvidia and AMD platforms.  
 In addition, HIP defines portable mechanisms to query architectural features, and supports a larger 64-bit wavesize which expands the return type for cross-lane functions like ballot and shuffle from 32-bit ints to 64-bit ints.  
 
 ### Can I develop HIP code on an Nvidia CUDA platform?
-Yes!  HIP's CUDA path only exposes the APIs and functionality that work on both NVCC and HCC back-ends.
-"Extra" APIs, parameters, and features which exist in CUDA but not in HCC will typically result in compile-time or run-time errors.
-Developers need to use the HIP API for most accelerator code, and bracket any CUDA-specific code with appropriate ifdefs.
+Yes.  HIP's CUDA path only exposes the APIs and functionality that work on both NVCC and HCC back-ends.
+"Extra" APIs, parameters, and features which exist in CUDA but not in HCC will typically result in compile- or run-time errors.
+Developers need to use the HIP API for most accelerator code, and bracket any CUDA-specific code with preprocessor conditionals.
 Developers concerned about portability should of course run on both platforms, and should expect to tune for performance.
 In some cases CUDA has a richer set of modes for some APIs, and some C++ capabilities such as virtual functions - see the HIP @API documentation for more details.
 
 ### Can I develop HIP code on an AMD HCC platform?
-Yes! HIP's HCC path only exposes the APIs and functions that work on both NVCC and HCC back ends. "Extra" APIs, parameters and features that appear in HCC but not CUDA will typically cause compile- or run-time errors. Developers must use the HIP API for most accelerator code and bracket any HCC-specific code with appropriate ifdefs. Those concerned about portability should, of course, test their code on both platforms and should tune it for performance. Typically, HCC supports a more modern set of C++11/C++14/C++17 features, so HIP developers who want portability should be careful when using advanced C++ features on the hc path.
+Yes. HIP's HCC path only exposes the APIs and functions that work on both NVCC and HCC back ends. "Extra" APIs, parameters and features that appear in HCC but not CUDA will typically cause compile- or run-time errors. Developers must use the HIP API for most accelerator code and bracket any HCC-specific code with preprocessor conditionals. Those concerned about portability should, of course, test their code on both platforms and should tune it for performance. Typically, HCC supports a more modern set of C++11/C++14/C++17 features, so HIP developers who want portability should be careful when using advanced C++ features on the hc path.
 
 ### Can a HIP binary run on both AMD and Nvidia platforms?
 HIP is a source-portable language that can be compiled to run on either the HCC or NVCC platform. HIP tools don't create a "fat binary" that can run on either platform, however.
@@ -184,9 +184,9 @@ A C++ dialect, hc is supported by the AMD HCC compiler. It provides C++ run time
 
 
 ### On HCC, can I link HIP code with host code compiled with another compiler such as gcc, icc, or clang ?
-Yes!  HIP/HCC generates the object code which conforms to the GCC ABI, and also links with libstdc++.  This means you can compile host code with the compiler of your choice and link this
-with GPU code compiler with HIP.  Larger projects often contain a mixture of accelerator code (initially written in CUDA with nvcc) plus host code (compiled with gcc, icc, or clang).   These projects
-can convert the accelerator code to HIP, compile that code with hipcc, and link with object code from the preferred compiler.S
+Yes.  HIP/HCC generates the object code which conforms to the GCC ABI, and also links with libstdc++.  This means you can compile host code with the compiler of your choice and link the generated object code
+with GPU code compiled with HIP.  Larger projects often contain a mixture of accelerator code (initially written in CUDA with nvcc) and host code (compiled with gcc, icc, or clang).   These projects
+can convert the accelerator code to HIP, compile that code with hipcc, and link with object code from their preferred compiler.
 
 
 
@@ -198,7 +198,7 @@ Sometimes this isn't what you want - you can force HIP to recognize the platform
 export HIP_PLATFORM=hcc
 
 ```
-One symptom of this problem is the message "error: 'unknown error'(11) at square.hipref.cpp:56".  This can occur if you have a CUDA installation on an AMD platform, and HIP incorrectly detects the platform as nvcc.  HIP may be able to compile the application using the nvcc tool-chain, but will generate this error at runtime since the platform does not have a CUDA device. The fix is to set HIP_PLATFORM=hcc and rebuild the issue. 
+One symptom of this problem is the message "error: 'unknown error'(11) at square.hipref.cpp:56".  This can occur if you have a CUDA installation on an AMD platform, and HIP incorrectly detects the platform as nvcc.  HIP may be able to compile the application using the nvcc tool-chain, but will generate this error at runtime since the platform does not have a CUDA device. The fix is to set HIP_PLATFORM=hcc and rebuild. 
 
 If you see issues related to incorrect platform detection, please file an issue with the GitHub issue tracker so we can improve HIP's platform detection logic.
 
@@ -207,7 +207,7 @@ Yes. You can use HIP_PLATFORM to choose which path hipcc targets.  This configur
 
 
 ### On CUDA, can I mix CUDA code with HIP code?
-Yes.  Most HIP data structures (hipStream_t, hipEvent_t) are typedefs to CUDA equivalents and can be intermixed.  Both CUDA and HIP use integer device ids .
+Yes.  Most HIP data structures (hipStream_t, hipEvent_t) are typedefs to CUDA equivalents and can be intermixed.  Both CUDA and HIP use integer device ids.
 One notable exception is that hipError_t is a new type, and cannot be used where a cudaError_t is expected.  In these cases, refactor the code to remove the expectation.  Alternatively, hip_runtime_api.h defines functions which convert between the error code spaces:
 
 hipErrorToCudaError
@@ -218,10 +218,10 @@ If platform portability is important, use #ifdef __HIP_PLATFORM_NVCC__ to guard 
 
 ### On HCC, can I use HC functionality with HIP?
 Yes.  
-The code can include hc.hpp and use HC functions inside the kernel.  A typical use case is to use AMD-specific hardware features such as the permute, swizzle, or DPP operations.
+The code can include hc.hpp and use HC functions inside the kernel.  A typical use-case is to use AMD-specific hardware features such as the permute, swizzle, or DPP operations.
 The "-stdlib=libc++" must be passed to hipcc in order to compile hc.hpp.  See the 'bit_extract' sample for an example. 
 
-Also these functions can be used to extract HCC acclerator and accelerator_view structures from the HIP deviceId and hipStream_t:
+Also these functions can be used to extract HCC accelerator and accelerator_view structures from the HIP deviceId and hipStream_t:
 hipHccGetAccelerator(int deviceId, hc::accelerator *acc);
 hipError_t hipHccGetAcceleratorView(hipStream_t stream, hc::accelerator_view **av);
 

--- a/docs/markdown/hip_performance.md
+++ b/docs/markdown/hip_performance.md
@@ -6,18 +6,18 @@ Please note that this document lists possible ways for experimenting with HIP st
  
 #### On Small BAR Setup
 
-There are two possible ways to transfer data from Host to Device (H2D) and Device to Host(D2H)
+There are two possible ways to transfer data from host-to-device (H2D) and device-to-host(D2H)
  * Using Staging Buffers
  * Using PinInPlace
 
 #### On Large BAR Setup
 
-There are three possible ways to transfer data from Host to Device (H2D)
+There are three possible ways to transfer data from host-to-device (H2D)
  * Using Staging Buffers
  * Using PinInPlace
  * Direct Memcpy
  
- And there are two possible ways to transfer data from Device to Host (D2H)
+ And there are two possible ways to transfer data from device-to-host (D2H)
  * Using Staging Buffers
  * Using PinInPlace
  

--- a/docs/markdown/hip_porting_driver_api.md
+++ b/docs/markdown/hip_porting_driver_api.md
@@ -1,7 +1,7 @@
 # Porting CUDA Driver API
 
 ## Introduction to the CUDA Driver and Runtime APIs
-CUDA provides a separate CUDA Driver and Runtime APIs.  The two APis have significant overlap in functionality:  
+CUDA provides a separate CUDA Driver and Runtime APIs.  The two APIs have significant overlap in functionality:  
 - Both APIs support events, streams, memory management, memory copy, and error handling.
 - Both APIs deliver similar performance.  
 - Driver APIs calls begin with the prefix `cu` while Runtime APIs begin with the prefix `cuda`.  For example, the Driver API API contains `cuEventCreate` while the Runtime API contains `cudaEventCreate`, with similar functionality.
@@ -90,14 +90,14 @@ the context.  The current context is implicitly used by other APIs such as `hipS
 The hipify tool will convert CUDA Driver APIs for streams, events, memory management to 
 the equivalent HIP driver calls.   For example, `cuEventCreate` will be translated to 
 `hipEventCreate`.  Hipify also converts error code from the Driver namespace and coding
-convention to the equivalent HIP error code.  Thus, HIP unifies the APis for these common functions.
+convention to the equivalent HIP error code.  Thus, HIP unifies the APIs for these common functions.
 [hipify support for translating driver API is Under Development]
 
 The memory copy APIs require additional explanation.  The CUDA driver includes the memory
 direction in the name of the API (ie `cuMemcpyH2D`) while the CUDA driver API provides
 a single memory copy API with a parameter that specifies the direction and additionally
 supports a "default" direction where the runtime determines the direction automatically.
-HIP provides APis with both styles: for example, `hipMemcpyH2D` as well as `hipMemcpy`.
+HIP provides APIs with both styles: for example, `hipMemcpyH2D` as well as `hipMemcpy`.
 The first flavor may be faster in some cases since they avoid host overhead to detect the 
 different memory directions.
 

--- a/docs/markdown/hip_porting_driver_api.md
+++ b/docs/markdown/hip_porting_driver_api.md
@@ -31,8 +31,8 @@ accelerator language front-end.  Here, NVCC is not used.   Instead, the environm
 different kernel language or different compilation flow.
 Other environments have many kernels and do not want them to be all loaded automatically.
 The Module functions can be used to load the generated code objects and launch kernels.
-As we will see below, HIP defines a Module API which provides similar explict control over code
-object managemenet.
+As we will see below, HIP defines a Module API which provides similar explicit control over code
+object management.
 
 ### cuCtx API
 The Driver API defines "Context" and "Devices" as separate entities.  

--- a/docs/markdown/hip_porting_guide.md
+++ b/docs/markdown/hip_porting_guide.md
@@ -1,5 +1,5 @@
 # HIP Porting Guide 
-In addition to providing a portable C++ programmming environement for GPUs, HIP is designed to ease
+In addition to providing a portable C++ programming environment for GPUs, HIP is designed to ease
 the porting of existing CUDA code into the HIP environment.  This section describes the available tools 
 and provides practical suggestions on how to port CUDA code and work through common issues. 
 
@@ -553,7 +553,7 @@ If you pass a ".cu" file, hcc will attempt to compile it as a Cuda language file
 
 ### HIP Environment Variables
 
-On the HCC path, HIP provides a number of environment variables that control the behavior of HIP.  Some of these are useful for appliction development (for example HIP_VISIBLE_DEVICES, HIP_LAUNCH_BLOCKING),
+On the HCC path, HIP provides a number of environment variables that control the behavior of HIP.  Some of these are useful for application development (for example HIP_VISIBLE_DEVICES, HIP_LAUNCH_BLOCKING),
 some are useful for performance tuning or experimentation (for example HIP_STAGING*), and some are useful for debugging (HIP_DB).  You can see the environment variables supported by HIP as well as
 their current values and usage with the environment var "HIP_PRINT_ENV" - set this and then run any HIP application.  For example:
 

--- a/docs/markdown/hip_profiling.md
+++ b/docs/markdown/hip_profiling.md
@@ -92,11 +92,11 @@ HIP_PROFILE_API supports two levels of information.
 
 #### Adding markers to applications
 
-Markers can be used to define application-specific events that will be recorded in the ATP file and displayed in the CodeXL gui.
+Markers can be used to define application-specific events that will be recorded in the ATP file and displayed in the CodeXL GUI.
 This can be particularly useful for visualizing how the higher-level phases of application behavior relate to the lower level HIP APIs, kernel launches, and data transfers.
 For example, an instrumented machine learning framework could show the beginning and ending of each layer in the network.
 
-Markers have a specific begin and end time, and can be nested.  Nested calls are displayed hierarchically in the CodeXL gui, with each level of the hierarchy occupying a different row.
+Markers have a specific begin and end time, and can be nested.  Nested calls are displayed hierarchically in the CodeXL GUI, with each level of the hierarchy occupying a different row.
 
 The HIP APis are defined in "hip_profile.h":
 ```
@@ -131,7 +131,7 @@ The HIP marker API is only supported on ROCm platform.  The marker macros are de
 
 This [HIP sample](samples/2_Cookbook/2_Profiler/) shows the profiler marker API used in a small application.
 
-More information on the marker API can be found in the profiler header file and PDF in a ROCM installation:
+More information on the marker API can be found in the profiler header file and PDF in a ROCm installation:
 - /opt/rocm/profiler/CXLActivityLogger/include/CXLActivityLogger.h
 - /opt/rocm/profiler/CXLActivityLogger/doc/CXLActivityLogger.pdf
 
@@ -185,7 +185,7 @@ $ nvprof --profile-from-start-off ...
 This feature is under development.
 
 #### Reducing timeline trace output file size
-If the application is already recording the HIP APIs, the HSA APIs are somewhat redundant and the ATP file size can be substantially reduced by not recording these APIs.  HIP includes a text file that lists all of the HSA APis and can assist in this filtering:
+If the application is already recording the HIP APIs, the HSA APIs are somewhat redundant and the ATP file size can be substantially reduced by not recording these APIs.  HIP includes a text file that lists all of the HSA APIs and can assist in this filtering:
 
 ```
 $ rocm-profiler -F hip/bin/hsa-api-filter-cxl.txt 
@@ -273,7 +273,7 @@ None will disable use of color control codes for both the opening and closing an
 
 This flag is primarily targeted to assist HIP development team in the development of the HIP runtime, but in some situations may be useful to HIP application developers as well.
 The HIP debug information is designed to print important information during the execution of a HIP API.  HIP provides
-different color-coded levels of debug informaton:
+different color-coded levels of debug information:
   - api  : Print the beginning and end of each HIP API, including the arguments and return codes.  This is equivalent to setting HIP_TRACE_API=1.
   - sync : Print multi-thread and other synchronization debug information.
   - copy : Print which engine is doing the copy, which copy flavor is selected, information on source and destination memory.

--- a/docs/markdown/hip_terms2.md
+++ b/docs/markdown/hip_terms2.md
@@ -13,7 +13,7 @@ The default device can be set with hipSetDevice.
 - hcc = Heterogeneous Compute Compiler (https://bitbucket.org/multicoreware/hcc/wiki/Home).  
 
 - hipify - tool to convert CUDA(R) code to portable C++ code.
-- hipconfig - tool to report various confoguration properties of the target platform.
+- hipconfig - tool to report various configuration properties of the target platform.
 
 - nvcc = nvcc compiler, do not capitalize.
 - hcc  = heterogeneous compute compiler, do not capitalize.

--- a/samples/2_Cookbook/2_Profiler/Readme.md
+++ b/samples/2_Cookbook/2_Profiler/Readme.md
@@ -22,7 +22,7 @@ We will be using the Simple Matrix Transpose source code from the previous tutor
 
 HIP can generate markers at function being/end which are displayed on the CodeXL timeline view. To do this, you need to install ROCm-Profiler and enable HIP to generate the markers:
 
-1. Install ROCm-Profiler Installing HIP from the rocm pre-built packages, installs the ROCm-Profiler as well. Alternatively, you can build ROCm-Profiler using the instructions given below.
+1. Install ROCm-Profiler Installing HIP from the ROCm pre-built packages, installs the ROCm-Profiler as well. Alternatively, you can build ROCm-Profiler using the instructions given below.
 
 
 2. Run with profiler enabled to generate ATP file.


### PR DESCRIPTION
I read through some of the documentation and found a number of spelling errors.